### PR TITLE
Update W3C header parsing

### DIFF
--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -139,8 +139,8 @@ if subsystem == "http" then
 
     -- Set the W3C Trace Context header
     -- TODO: Should W3C traceparent header be set even it wasn't on the incoming request?
-    -- TODO: Is .. concatenation performant?
-    set_header("Traceparent", "00-".. to_hex(proxy_span.trace_id) .. "-" .. to_hex(proxy_span.span_id) .. "-" .. tostring(proxy_span.should_sample and "01" or "00"))
+    set_header("traceparent", "00-".. to_hex(proxy_span.trace_id) .. "-" .. to_hex(proxy_span.span_id) .. "-" ..
+      tostring(proxy_span.should_sample and "01" or "00"))
 
     -- TODO: Should B3 headers be set even if they weren't on the incoming request?
     -- We want to remove headers if already present


### PR DESCRIPTION
- Add tests.
- Update header set to be lowercase.
- Optimize the pattern matching of the header value.
- Refactor parsing function for ease of reading.
- Fix linting.